### PR TITLE
Add default export to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "type": "module",
   "exports": {
     "types": "./dist/index.d.ts",
-    "import": "./dist/index.js"
+    "import": "./dist/index.js",
+    "default": "./dist/index.js"
   },
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
Seems some bundlers (webpack, turbopack) can't import this when the rehype package is passed as a string. 

Tracking the issue here, but adding the default key also fixes it.

 Same issue this package, the merge fixed it. https://github.com/stefanprobst/rehype-extract-toc/pull/10

tracking the issue: https://github.com/vercel/next.js/issues/73757

Would appreciate if you could merge + cut a release. 